### PR TITLE
State filter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "python.pythonPath": "/home/sglyon/anaconda3/envs/cmdc/bin/python"
+    "python.pythonPath": "/home/sglyon/anaconda3/envs/cmdc/bin/python",
+    "python.linting.prospectorEnabled": true,
+    "python.linting.enabled": true
 }

--- a/cmdc/__init__.py
+++ b/cmdc/__init__.py
@@ -1,2 +1,2 @@
-from . import client
-from .client import Client
+from . import client  # noqa: F401
+from .client import Client  # noqa: F401

--- a/cmdc/client.py
+++ b/cmdc/client.py
@@ -15,10 +15,6 @@ BASE_URL = "https://api.covid.valorum.ai"
 
 
 class Endpoint:
-    """
-    Internal class to be used when building up a request
-    """
-
     def __init__(self, client: "Client", path: str, parameters: List[Dict[str, List]]):
         """
         Create a Endpoint builder object
@@ -92,6 +88,10 @@ class Endpoint:
             f"\n\n\n{description}"
         )
         return msg
+
+    @property
+    def __doc__(self):
+        return self.__repr__()
 
 
 #%%

--- a/cmdc/client.py
+++ b/cmdc/client.py
@@ -73,9 +73,11 @@ class Request:
 
     def __repr__(self) -> str:
         filter_names = [x["name"] for x in self.valid_filters]
+        description = self.client._spec["paths"]["/" + self.path]["get"]["description"]
         msg = (
             f"Request builder for {self.path} endpoint"
             f"\nValid filters are {', '.join(filter_names)}"
+            f"\n\n\n{description}"
         )
         return msg
 

--- a/cmdc/client.py
+++ b/cmdc/client.py
@@ -196,7 +196,7 @@ class Client:
     def fips_in_states(self, states: Union[List[int], int]):
         if isinstance(states, (int, str)):
             states = [states]
-        states = [int(us.states.lookup(str(x)).fips) for x in states]
+        states = [int(us.states.lookup(str(x).zfill(2)).fips) for x in states]
         fips = self.counties.query("state in @states")["fips"].unique()
         return sorted(list(fips)) + states
 

--- a/cmdc/client.py
+++ b/cmdc/client.py
@@ -10,14 +10,14 @@ import pandas as pd
 BASE_URL = "https://api.covid.valorum.ai"
 
 
-class Request:
+class Endpoint:
     """
     Internal class to be used when building up a request
     """
 
     def __init__(self, client: "Client", path: str, parameters: List[Dict[str, List]]):
         """
-        Create a Request builder object
+        Create a Endpoint builder object
 
         Parameters
         ----------
@@ -25,7 +25,7 @@ class Request:
             The API Client that should be returned after calling an instance of
             this class
         path: string
-            The API path for which the Request will be built
+            The API path for which the Endpoint will be built
         parameters: List[Dict[str, List]]
             A list of OpenAPI 2.0 parameters for this endpoint
         """
@@ -358,13 +358,13 @@ class Client:
         return output
 
     ## Dynamic query builder
-    def __getattr__(self, ds: str) -> Request:
+    def __getattr__(self, ds: str) -> Endpoint:
         if ds not in dir(self):
             msg = f"Unknown dataset {ds}. Known datasets are {dir(self)}"
             raise ValueError(msg)
 
         route = self._spec["paths"]["/" + ds]["get"]
-        return Request(self, ds, route["parameters"])
+        return Endpoint(self, ds, route["parameters"])
 
     def __dir__(self) -> List[str]:
         paths = self._spec["paths"]

--- a/cmdc/client.py
+++ b/cmdc/client.py
@@ -67,7 +67,6 @@ class Request:
                 )
                 raise ValueError(msg)
 
-
         self.client.add_request(self.path, filters)
 
         return self.client
@@ -81,15 +80,24 @@ class Request:
         return msg
 
 
+#%%
 def create_filter_rhs(x: Any) -> str:
-    """
-    Parse the string `x` to be a postgrest accepted string for filtering
-    rows
-    """
-    # TODO: handle more than just eq
+    ineqs = {">": "gt", "<": "lt", "!=": "neq"}
+    if isinstance(x, (list, tuple, set)):
+        # use in
+        return f"in.({','.join(map(str, x))})"
+
+    if isinstance(x, str):
+        # check for inequality
+        for op in ineqs:
+            if op in x:
+                if f"{op}=" in x:
+                    return x.replace(f"{op}=", ineqs[op] + "e.")
+                return x.replace(op, ineqs[op] + ".")
     return f"eq.{x}"
 
 
+#%%
 class Client:
     def __init__(self, apikey=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from os import path
 
 here = path.abspath(path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     packages=["cmdc"],
     python_requires='>=3.5, <4',
-    install_requires=["requests", "pandas", "email_validator"],
+    install_requires=["requests", "pandas", "email_validator", "us"],
     project_urls={  # Optional
         'Bug Reports': 'https://github.com/valorumdata/cmdc.py/issues',
         'Source': 'https://github.com/valorumdata/cmdc.py',


### PR DESCRIPTION
This does a few things:

- Fixes lint/formatting/style errors
- Adds support for inequality operators in filters
- Adds support for passing a list/tuple/set to a filter -- acts like `col IN val`
- Renames request to endpoint
- Adds a retry adapter to the reqeusts session so we can get automatic retry in case something wonky happens on initial request
- Adds a state filter to all endpoints. This lets you do stuff like `c.covid(state="NY")` or `c.covid(state=36)` to get data for new york. You can also do `c.covid(state=["FL", 36])`, `c.covid(state=["FL", "NY"])`, `c.covid(state=[12, 36])`, `c.covid(state=[12, "NY"])` to get data for florida and NY